### PR TITLE
Fix bug with torch damage text getting overridden by spread text

### DIFF
--- a/effects/do_nothing_effect.gd
+++ b/effects/do_nothing_effect.gd
@@ -1,0 +1,13 @@
+class_name DoNothingEffect
+extends Effect
+
+func apply()->void :
+	pass
+
+
+func unapply()->void :
+	pass
+
+
+func get_args()->Array:
+	return []

--- a/effects/torch_spread_text.tres
+++ b/effects/torch_spread_text.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://mods-unpacked/DarkTwinge-BalanceMod/effects/do_nothing_effect.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+custom_key = "EFFECT_TORCH_SRPEAD_TEXT"
+text_key = "effect_burning_spread"

--- a/mod_main.gd
+++ b/mod_main.gd
@@ -861,6 +861,7 @@ func _ready()->void:
 	temp.cooldown = 21   # 18
 	
 	# Torch
+	var spread_text_effect = load("res://mods-unpacked/DarkTwinge-BalanceMod/effects/torch_spread_text.tres")
 	temp = load("res://weapons/melee/torch/1/torch_stats.tres")
 	temp.damage = 2    		# 1
 	##temp.max_range = 200  # 175
@@ -876,8 +877,8 @@ func _ready()->void:
 	temp.damage = 6    		# 5
 	temp.duration = 5  		# 4
 	temp.spread = 1				# 0
-	temp = load("res://weapons/melee/torch/2/torch_2_effect_1.tres")
-	temp.text_key = "effect_burning_spread"
+	temp = load("res://weapons/melee/torch/2/torch_2_data.tres")
+	temp.effects.append(spread_text_effect)
 	temp = load("res://weapons/melee/torch/3/torch_3_stats.tres")
 	temp.damage = 6    		# 1
 	##temp.max_range = 200  # 175
@@ -886,8 +887,8 @@ func _ready()->void:
 	temp.damage = 9    	 	# 8
 	temp.duration = 7  	  # 5
 	temp.spread = 1				# 0
-	temp = load("res://weapons/melee/torch/3/torch_3_effect_1.tres")
-	temp.text_key = "effect_burning_spread"
+	temp = load("res://weapons/melee/torch/3/torch_3_data.tres")
+	temp.effects.append(spread_text_effect)
 	temp = load("res://weapons/melee/torch/4/torch_4_stats.tres")
 	temp.damage = 8   	  # 1
 	##temp.max_range = 200  # 175
@@ -896,8 +897,8 @@ func _ready()->void:
 	temp.damage = 15   		# 12
 	temp.duration = 9  		# 8
 	temp.spread = 1       # 0
-	temp = load("res://weapons/melee/torch/4/torch_4_effect_1.tres")
-	temp.text_key = "effect_burning_spread"
+	temp = load("res://weapons/melee/torch/4/torch_4_data.tres")
+	temp.effects.append(spread_text_effect)
 	
 	# Bokken (Fighting Stick)
 	temp = load("res://weapons/melee/fighting_stick/1/fighting_stick_data.tres")


### PR DESCRIPTION
* Adds an effect that does nothing as a hacky way to add text to the torch while still just using the existing burn effect to apply the spread without overriding its own text.