### PR TITLE
Fix bug with fairy indicator not applying right away

### DIFF
--- a/extensions/ui/menus/shop/shop_item.gd
+++ b/extensions/ui/menus/shop/shop_item.gd
@@ -56,7 +56,7 @@ func set_shop_item(p_item_data:ItemParentData, p_wave_value:int = RunData.curren
 			texture.create_from_image(icon)
 			color = Color.white	
 	# Replace material icon with fairy for shop items that fairy is affected by
-	elif RunData.get_nb_item("item_fairy") > 0 and item_data is ItemData and (item_data.tier == Tier.COMMON or item_data.tier == Tier.LEGENDARY):
+	elif RunData.get_nb_item("item_fairy", false) > 0 and item_data is ItemData and (item_data.tier == Tier.COMMON or item_data.tier == Tier.LEGENDARY):
 		
 		var already_has_item = false
 

--- a/extensions/ui/menus/upgrades/item_box_ui.gd
+++ b/extensions/ui/menus/upgrades/item_box_ui.gd
@@ -47,7 +47,7 @@ func set_item_data(p_item_data:ItemParentData)->void :
 			texture.create_from_image(icon)
 			_take_button.icon = texture	
 	# Add Fairy icon to item crates for unobtained tier-1s & tier-4s
-	elif RunData.get_nb_item("item_fairy") > 0 and item_data is ItemData and (item_data.tier == Tier.COMMON or item_data.tier == Tier.LEGENDARY):
+	elif RunData.get_nb_item("item_fairy", false) > 0 and item_data is ItemData and (item_data.tier == Tier.COMMON or item_data.tier == Tier.LEGENDARY):
 		
 		var already_has_item = false
 


### PR DESCRIPTION
item count cache doesn't seem to work properly, passing in false makes it not use it.

More specifically, that function is intended to be called during the wave; the items you have don't change during a wave, and it resets the cache at the start of the wave. So it would just check and initialize the correct value and it would be accurate for the rest of the wave. By checking the value in our added fairy shop code, we would initialize it with a value of 0 and then it wouldn't be updated. We don't need to use the cache for these calls because they're not running every frame or whatever anyway.